### PR TITLE
Replace ReadAll calls

### DIFF
--- a/model/tsreponse.go
+++ b/model/tsreponse.go
@@ -4,11 +4,11 @@ import "encoding/xml"
 
 // TsResponse is the wrapper that Tableau Server wraps each response with
 type TsResponse struct {
-	XMLName     xml.Name    `json:"-" xml:"tsResponse"`
-	ServerInfo  ServerInfo  `json:"serverInfo" xml:"serverInfo"`
-	Credentials Credentials `json:"credentials" xml:"credentials"`
-	Error       ErrorType   `json:"error" xml:"error"`
-	Site        SiteType    `json:"site" xml:"site"`
+	XMLName     xml.Name    `json:"-"            xml:"tsResponse"`
+	ServerInfo  ServerInfo  `json:"serverInfo"   xml:"serverInfo"`
+	Credentials Credentials `json:"credentials"  xml:"credentials"`
+	Error       ErrorType   `json:"error"        xml:"error"`
+	Site        SiteType    `json:"site"         xml:"site"`
 }
 
 // ServerInfo contains information about product version and api version for the server
@@ -19,49 +19,49 @@ type ServerInfo struct {
 }
 
 type SiteType struct {
-	XMLName      xml.Name `json:"-" xml:"site"`
-	ID           string   `json:"id,omitempty" xml:"id,attr,omitempty"`
-	Name         string   `json:"name,omitempty" xml:"name,attr,omitempty"`
-	ContentUrl   string   `json:"contentUrl,omitempty" xml:"contentUrl,attr,omitempty"`
-	AdminMode    string   `json:"adminMode,omitempty" xml:"adminMode,attr,omitempty"`
-	UserQuota    string   `json:"userQuota,omitempty" xml:"userQuota,attr,omitempty"`
-	StorageQuota int      `json:"storageQuota,omitempty" xml:"storageQuota,attr,omitempty"`
-	State        string   `json:"state,omitempty" xml:"state,attr,omitempty"`
-	StatusReason string   `json:"statusReason,omitempty" xml:"statusReason,attr,omitempty"`
+	XMLName      xml.Name `json:"-"                       xml:"site"`
+	ID           string   `json:"id,omitempty"            xml:"id,attr,omitempty"`
+	Name         string   `json:"name,omitempty"          xml:"name,attr,omitempty"`
+	ContentUrl   string   `json:"contentUrl,omitempty"    xml:"contentUrl,attr,omitempty"`
+	AdminMode    string   `json:"adminMode,omitempty"     xml:"adminMode,attr,omitempty"`
+	UserQuota    string   `json:"userQuota,omitempty"     xml:"userQuota,attr,omitempty"`
+	StorageQuota int      `json:"storageQuota,omitempty"  xml:"storageQuota,attr,omitempty"`
+	State        string   `json:"state,omitempty"         xml:"state,attr,omitempty"`
+	StatusReason string   `json:"statusReason,omitempty"  xml:"statusReason,attr,omitempty"`
 	Usage        struct {
-		NumUsers     uint `json:"numUsers" xml:"numUsers,attr"`
-		NumCreators  uint `json:"numCreators,omitempty" xml:"numCreators,omitempty,attr"`
-		NumExplorers uint `json:"numExplorers,omitempty" xml:"numExplorers,omitempty,attr"`
-		NumViewers   uint `json:"numViewers,omitempty" xml:"numViewers,omitempty,attr"`
-		Storage      uint `json:"storage" xml:"storage,attr"`
-	} `json:"usage,omitempty" xml:"usage,omitempty"`
+		NumUsers     uint `json:"numUsers"                xml:"numUsers,attr"`
+		NumCreators  uint `json:"numCreators,omitempty"   xml:"numCreators,omitempty,attr"`
+		NumExplorers uint `json:"numExplorers,omitempty"  xml:"numExplorers,omitempty,attr"`
+		NumViewers   uint `json:"numViewers,omitempty"    xml:"numViewers,omitempty,attr"`
+		Storage      uint `json:"storage"                 xml:"storage,attr"`
+	} `json:"usage,omitempty"  xml:"usage,omitempty"`
 }
 
 type Credentials struct {
-	XMLName     xml.Name  `json:"-" xml:"credentials"`
-	Name        string    `json:"name,omitempty" xml:"name,attr,omitempty"`
-	Password    string    `json:"password,omitempty" xml:"password,attr,omitempty"`
-	Token       string    `json:"token,omitempty" xml:"token,attr,omitempty"`
-	Site        *SiteType `json:"site,omitempty" xml:"site,omitempty"`
-	Impersonate *User     `json:"user,omitempty" xml:"user,omitempty"`
+	XMLName     xml.Name  `json:"-"                   xml:"credentials"`
+	Name        string    `json:"name,omitempty"      xml:"name,attr,omitempty"`
+	Password    string    `json:"password,omitempty"  xml:"password,attr,omitempty"`
+	Token       string    `json:"token,omitempty"     xml:"token,attr,omitempty"`
+	Site        *SiteType `json:"site,omitempty"      xml:"site,omitempty"`
+	Impersonate *User     `json:"user,omitempty"      xml:"user,omitempty"`
 }
 type ProductVersion struct {
-	XMLName xml.Name `json:"-" xml:"productVersion"`
-	Value   string   `json:"value" xml:",chardata"`
-	Build   string   `json:"build" xml:"build,attr"`
+	XMLName xml.Name `json:"-"      xml:"productVersion"`
+	Value   string   `json:"value"  xml:",chardata"`
+	Build   string   `json:"build"  xml:"build,attr"`
 }
 
 type User struct {
-	XMLName  xml.Name `json:"-" xml:"user"`
-	ID       string   `json:"id,omitempty" xml:"id,attr,omitempty"`
-	Name     string   `json:"name,omitempty" xml:"name,attr,omitempty"`
-	SiteRole string   `json:"siteRole,omitempty" xml:"siteRole,attr,omitempty"`
-	FullName string   `json:"fullName,omitempty" xml:"fullName,attr,omitempty"`
+	XMLName  xml.Name `json:"-"                   xml:"user"`
+	ID       string   `json:"id,omitempty"        xml:"id,attr,omitempty"`
+	Name     string   `json:"name,omitempty"      xml:"name,attr,omitempty"`
+	SiteRole string   `json:"siteRole,omitempty"  xml:"siteRole,attr,omitempty"`
+	FullName string   `json:"fullName,omitempty"  xml:"fullName,attr,omitempty"`
 }
 
 type ErrorType struct {
-	XMLName xml.Name `json:"-" xml:"error"`
-	Summary string   `json:"summary" xml:"summary"`
-	Detail  string   `json:"detail" xml:"detail"`
-	Code    uint     `json:"code" xml:"code,attr"`
+	XMLName xml.Name `json:"-"        xml:"error"`
+	Summary string   `json:"summary"  xml:"summary"`
+	Detail  string   `json:"detail"   xml:"detail"`
+	Code    uint     `json:"code"     xml:"code,attr"`
 }

--- a/model/tsrequest.go
+++ b/model/tsrequest.go
@@ -4,9 +4,9 @@ import "encoding/xml"
 
 // TsRequest is the wrapper that Tableau Server expects requests to be wrapped with
 type TsRequest struct {
-	XMLName     xml.Name    `json:"-" xml:"tsRequest"`
-	Credentials Credentials `json:"credentials,omitempty" xml:"credentials,omitempty"`
-	Site        SiteType    `json:"site,omitempty" xml:"site,omitempty"`
+	XMLName     xml.Name    `json:"-"                      xml:"tsRequest"`
+	Credentials Credentials `json:"credentials,omitempty"  xml:"credentials,omitempty"`
+	Site        SiteType    `json:"site,omitempty"         xml:"site,omitempty"`
 }
 
 //

--- a/types.go
+++ b/types.go
@@ -1,5 +1,7 @@
 package gotabgo
 
+import "errors"
+
 type ContentType int
 
 const (
@@ -9,6 +11,17 @@ const (
 
 func (r ContentType) String() string {
 	return [...]string{"application/json", "application/xml"}[r]
+}
+
+func ContentTypeString(s string) (c ContentType, e error) {
+	var cTypeMap = map[string]ContentType{"application/json": Json, "application/xml": Xml}
+	var ok bool
+
+	if c, ok = cTypeMap[s]; ok {
+		return
+	}
+	e = errors.New("Content Type can't be converted")
+	return
 }
 
 type TabApi struct {


### PR DESCRIPTION
- Add method to convert string to type
- Create worker function to put response into struct
- Replace ReadAll with helper function call

ReadAll will read into memory the entire contents of the body. This is risky. Using a decoder is safer and more memory efficient.
